### PR TITLE
README: fix typo in softether name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Warning:  code in this repository is work in progress and currently not usable y
   * terms of access (max clients, etc)
 * gateway server support
   * openvpn
-  * softeather
+  * softether
   * cjdns gateway
   * simple forwarding configuration
   * other methods


### PR DESCRIPTION
Someone linked project on hypeirc and when skimming readme that typo really bugged me ;)
